### PR TITLE
MRG: Add support for channel types, add .DS_Store to .gitignore, add a conversion to str for fname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 cython_debug/
 
 /doc/generated/
+.DS_Store

--- a/eeglabio/epochs.py
+++ b/eeglabio/epochs.py
@@ -117,4 +117,4 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
                  icawinv=[],
                  icasphere=[],
                  icaweights=[])
-    savemat(fname, eeg_d, appendmat=False)
+    savemat(str(fname), eeg_d, appendmat=False)

--- a/eeglabio/raw.py
+++ b/eeglabio/raw.py
@@ -81,4 +81,4 @@ def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
                             names=["type", "latency", "duration"])
         eeg_d['event'] = events
 
-    savemat(fname, eeg_d, appendmat=False)
+    savemat(str(fname), eeg_d, appendmat=False)

--- a/eeglabio/raw.py
+++ b/eeglabio/raw.py
@@ -49,13 +49,13 @@ def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
 
     data = data * 1e6  # convert to microvolts
 
+    # channel types
+    ch_types = np.array(ch_types) if ch_types is not None \
+        else np.repeat('', len(ch_names))
+
     if ch_locs is not None:
         # get full EEGLAB coordinates to export
         full_coords = cart_to_eeglab(ch_locs)
-
-        # channel types
-        ch_types = np.array(ch_types) if ch_types is not None \
-            else np.repeat('', len(ch_names))
 
         # convert to record arrays for MATLAB format
         chanlocs = fromarrays(
@@ -64,7 +64,7 @@ def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
                    "sph_radius", "theta", "radius",
                    "sph_theta_besa", "sph_phi_besa", "type"])
     else:
-        chanlocs = fromarrays([ch_names], names=["labels"])
+        chanlocs = fromarrays([ch_names, ch_types], names=["labels", "type"])
 
     if isinstance(ref_channels, list):
         ref_channels = " ".join(ref_channels)

--- a/eeglabio/raw.py
+++ b/eeglabio/raw.py
@@ -6,7 +6,7 @@ from .utils import cart_to_eeglab
 
 
 def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
-               ref_channels="common"):
+               ref_channels="common", ch_types=None):
     """Export continuous raw data to EEGLAB's .set format.
 
     Parameters
@@ -34,6 +34,8 @@ def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
         specific reference set. Note that this parameter is only used to inform
         EEGLAB of the existing reference, this method will not reference the
         data for you.
+    ch_types : list of str | None
+        Channel types e.g. ‘EEG’, ‘MEG’, ‘EMG’, ‘ECG’, ‘Events’, ..
 
     See Also
     --------
@@ -51,9 +53,13 @@ def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
         # get full EEGLAB coordinates to export
         full_coords = cart_to_eeglab(ch_locs)
 
+        # channel types
+        ch_types = np.array(ch_types) if ch_types is not None \
+            else np.repeat('', len(ch_names))
+
         # convert to record arrays for MATLAB format
         chanlocs = fromarrays(
-            [ch_names, *full_coords.T, np.repeat('', len(ch_names))],
+            [ch_names, *full_coords.T, ch_types],
             names=["labels", "X", "Y", "Z", "sph_theta", "sph_phi",
                    "sph_radius", "theta", "radius",
                    "sph_theta_besa", "sph_phi_besa", "type"])

--- a/eeglabio/utils.py
+++ b/eeglabio/utils.py
@@ -189,11 +189,6 @@ def export_mne_raw(inst, fname):
         cart_coords = None
 
     ch_types = inst.get_channel_types()
-    ch_type_mapping = {'eeg': 'EEG', 'mag': 'MEG', 'grad': 'MEG', 'eog': 'EOG',
-                       'ecg': 'ECG', 'stim': 'Events'}
-    ch_types = [ch_type_mapping[ch] if ch in ch_type_mapping else ''
-                for ch in ch_types]
-
     annotations = [inst.annotations.description, inst.annotations.onset,
                    inst.annotations.duration]
     export_set(fname, inst.get_data(), inst.info['sfreq'],

--- a/eeglabio/utils.py
+++ b/eeglabio/utils.py
@@ -188,7 +188,13 @@ def export_mne_raw(inst, fname):
     else:
         cart_coords = None
 
+    ch_types = inst.get_channel_types()
+    ch_type_mapping = {'eeg': 'EEG', 'mag': 'MEG', 'grad': 'MEG', 'eog': 'EOG',
+                       'ecg': 'ECG', 'stim': 'Events'}
+    ch_types = [ch_type_mapping[ch] if ch in ch_type_mapping else ''
+                for ch in ch_types]
+
     annotations = [inst.annotations.description, inst.annotations.onset,
                    inst.annotations.duration]
     export_set(fname, inst.get_data(), inst.info['sfreq'],
-               inst.ch_names, cart_coords, annotations)
+               inst.ch_names, cart_coords, annotations, ch_types=ch_types)


### PR DESCRIPTION
Hello, I had to move some of my `-raw.fif` files to EEGLAB; and I noticed the lack of support for channels types (which is problematic for me). I'm adding it here, using the example channel types provided [here](https://eeglab.org/tutorials/04_Import/Channel_Locations.html).

A quick test shows that everything is working; the now loaded `.set` file in EEGLAB does show the correct channel types.
Please correct me if I'm wrong or if I overlooked anything.

I'm not adding anything to the test (yet) because `mne.io.read_raw_eeglab()` doesn't seem to support reading the channel types anyway. I will add it there as well when MNE release a version including https://github.com/mne-tools/mne-python/pull/9990

-------

I also added 2 more small improvements: 
- `.DS_Store` to the .gitignore for macOS developers.
- `str(fname)` before calling `scipy.io.savemat`. It's not uncommon for users to provide the path to a file as a `pathlib.Path` instance and this would raise an error in scipy.