### PR TITLE
MAINT: Ensure sdist works

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -30,6 +30,7 @@ jobs:
         pip install mne flake8 pytest twine pymatreader
         pip install -r requirements.txt
         pip install -e .
+        mne sys_info -d
       shell: bash -el {0}
     - name: Lint
       run: |

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install mne flake8 pytest twine
         pip install -r requirements.txt
+        pip install -e .
       shell: bash -el {0}
     - name: Lint
       run: |

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mne flake8 pytest
+        pip install mne flake8 pytest twine
         pip install -r requirements.txt
       shell: bash -el {0}
     - name: Lint

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install mne flake8 pytest
         pip install -r requirements.txt
+      shell: bash -el {0}
     - name: Lint
       run: |
         flake8 .
@@ -40,6 +41,11 @@ jobs:
       run: |
         pip install setuptools wheel twine
         python setup.py sdist bdist_wheel
+      shell: bash -el {0}
+    - name: Test sdist
+      run: |
+        pip install dist/*.tar.gz
+      shell: bash -el {0}
     - name: Publish to Test PyPI
       if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
       env:

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install mne flake8 pytest twine
+        pip install mne flake8 pytest twine pymatreader
         pip install -r requirements.txt
         pip install -e .
       shell: bash -el {0}

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -37,13 +37,14 @@ jobs:
       run: |
         pytest
     - name: Build Package
-      if: github.event_name == 'push' && (github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v'))
       run: |
         pip install setuptools wheel twine
         python setup.py sdist bdist_wheel
       shell: bash -el {0}
     - name: Test sdist
       run: |
+        twine check dist/*
+        ls dist/*.tar.gz | wc -l | grep "^1$"
         pip install dist/*.tar.gz
       shell: bash -el {0}
     - name: Publish to Test PyPI

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/eeglabio/_version.py
+++ b/eeglabio/_version.py
@@ -1,3 +1,3 @@
 """The version number."""
 
-__version__ = '0.0.1-6'
+__version__ = '0.0.1-7'

--- a/eeglabio/tests/test_raw.py
+++ b/eeglabio/tests/test_raw.py
@@ -1,7 +1,6 @@
 from os import path as op
 from pathlib import Path
 
-import pytest
 import numpy as np
 from mne.io import read_raw_fif, read_raw_eeglab
 from numpy.testing import assert_allclose
@@ -13,12 +12,11 @@ raw_fname = Path(__file__).parent / "data" / "test_raw.fif"
 
 def test_export_set(tmpdir):
     """Test saving a Raw instance to EEGLAB's set format"""
-    raw = read_raw_fif(raw_fname)
-    raw.load_data()
+    raw = read_raw_fif(raw_fname).pick_types(
+        meg=True, eeg=True, ecg=True).load_data()
     temp_fname = op.join(str(tmpdir), 'test_raw.set')
     export_mne_raw(raw, temp_fname)
-    with pytest.warns(RuntimeWarning, match='Not setting positions'):
-        raw_read = read_raw_eeglab(temp_fname, preload=True)
+    raw_read = read_raw_eeglab(temp_fname, preload=True)
     assert raw.ch_names == raw_read.ch_names
     cart_coords = np.array([d['loc'][:3] for d in raw.info['chs']])  # just xyz
     cart_coords_read = np.array([d['loc'][:3] for d in raw_read.info['chs']])

--- a/eeglabio/tests/test_raw.py
+++ b/eeglabio/tests/test_raw.py
@@ -1,6 +1,7 @@
 from os import path as op
 from pathlib import Path
 
+import pytest
 import numpy as np
 from mne.io import read_raw_fif, read_raw_eeglab
 from numpy.testing import assert_allclose

--- a/eeglabio/tests/test_raw.py
+++ b/eeglabio/tests/test_raw.py
@@ -16,10 +16,11 @@ def test_export_set(tmpdir):
     raw.load_data()
     temp_fname = op.join(str(tmpdir), 'test_raw.set')
     export_mne_raw(raw, temp_fname)
-    raw_read = read_raw_eeglab(temp_fname, preload=True)
+    with pytest.warns(RuntimeWarning, match='Not setting positions'):
+        raw_read = read_raw_eeglab(temp_fname, preload=True)
     assert raw.ch_names == raw_read.ch_names
     cart_coords = np.array([d['loc'][:3] for d in raw.info['chs']])  # just xyz
     cart_coords_read = np.array([d['loc'][:3] for d in raw_read.info['chs']])
-    assert_allclose(cart_coords, cart_coords_read)
-    assert_allclose(raw.times, raw_read.times)
-    assert_allclose(raw.get_data(), raw_read.get_data())
+    assert_allclose(cart_coords, cart_coords_read, atol=1e-5)
+    assert_allclose(raw.times, raw_read.times, atol=1e-5)
+    assert_allclose(raw.get_data(), raw_read.get_data(), atol=1e-11)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 scipy
+pymatreader

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 scipy
-pymatreader

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join('eeglabio', '_version.py'), 'r') as fid:
             version = line.split('=')[1].strip().strip("'")
             break
 if version is None:
-    version = "0.0.1"
+    raise RuntimeError('Could not obtain version')
 
 with open("requirements.txt") as f:
     requires = f.read().splitlines()
@@ -38,7 +38,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=setuptools.find_packages(exclude=("*tests",)),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     include_package_data=True,
     install_requires=requires,
     keywords="EEG MEG MNE EEGLAB",


### PR DESCRIPTION
According to https://github.com/conda-forge/staged-recipes/pull/18752 and my local testing, this test should work but fails currently with:
```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-9_2zenck/setup.py", line 16, in <module>
        with open("requirements.txt") as f:
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```
Once I see CIs come back red (true TDD!), I'll try adding a MANIFEST.in that should fix this.