### PR TITLE
Fix: `fromarrays` import for Numpy ≥2.0 compatibility

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -17,6 +17,9 @@ jobs:
   test-publish:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        numpy-version: ["1.26", "2.0", "2.2"]
 
     steps:
     - uses: actions/checkout@v4
@@ -27,6 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install numpy==${{ matrix.numpy-version }}
         pip install mne flake8 pytest twine pymatreader
         pip install -r requirements.txt
         pip install -e .

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install numpy==${{ matrix.numpy-version }}
         pip install mne flake8 pytest twine pymatreader
-        pip install -r requirements.txt
         pip install -e .
         mne sys_info -d
       shell: bash -el {0}

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -15,18 +15,25 @@ on:
 
 jobs:
   test-publish:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        numpy-version: ["1.26", "2.0", "2.2"]
+        include:
+          - python-version: "3.10"
+            numpy-version: "1.26.4"
+          - python-version: "3.10"
+            numpy-version: "2.0.2"
+          - python-version: "3.13"
+            numpy-version: "2.2.5"
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -36,23 +43,28 @@ jobs:
         pip install -e .
         mne sys_info -d
       shell: bash -el {0}
+
     - name: Lint
       run: |
         flake8 .
+
     - name: Test
       run: |
         pytest
+
     - name: Build Package
       run: |
         pip install setuptools wheel twine
         python setup.py sdist bdist_wheel
       shell: bash -el {0}
+
     - name: Test sdist
       run: |
         twine check dist/*
         ls dist/*.tar.gz | wc -l | grep "^1$"
         pip install dist/*.tar.gz
       shell: bash -el {0}
+
     - name: Publish to Test PyPI
       if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
       env:
@@ -60,6 +72,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
       run: |
         twine upload --repository testpypi dist/*
+
     - name: Publish to PyPI (release)
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       env:

--- a/eeglabio/raw.py
+++ b/eeglabio/raw.py
@@ -1,6 +1,10 @@
 import numpy as np
-from numpy.core.records import fromarrays
 from scipy.io import savemat
+
+try:
+    from numpy.rec import fromarrays  # NumPy 2.0+
+except ImportError:
+    from numpy.core.records import fromarrays  # NumPy <2.0
 
 from .utils import cart_to_eeglab
 


### PR DESCRIPTION
This PR ensures compatibility with Numpy ≥2.0, where `fromarrays` has been moved from `numpy.core.records` to `numpy.rec`.

A try/except fallback has been added to support both NumPy 1.x and 2.x.

Tested with:
- `numpy==1.26`
- `numpy==2.0`

Fixes #14
Related upstream: mne-tools/mne-python#12985
