### PR TITLE
replaced scipy.savemat with hdf5storage.savemat

### DIFF
--- a/eeglabio/_version.py
+++ b/eeglabio/_version.py
@@ -1,3 +1,3 @@
 """The version number."""
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'

--- a/eeglabio/epochs.py
+++ b/eeglabio/epochs.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.core.records import fromarrays
-from scipy.io import savemat
+from hdf5storage import savemat
 
 from .utils import cart_to_eeglab, logger
 
@@ -58,6 +58,8 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
     -----
     Channel locations are expanded to the full EEGLAB format.
     For more details see :func:`.utils.cart_to_eeglab_sph`.
+
+    Since 0.2.0, data is saved in matlabs v7.3 hdf5 format to support files large than 2GB
     """
 
     data = data * 1e6  # convert to microvolts

--- a/eeglabio/raw.py
+++ b/eeglabio/raw.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.io import savemat
+from hdf5storage import savemat
 
 try:
     from numpy.rec import fromarrays  # NumPy 2.0+
@@ -52,6 +52,8 @@ def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
     -----
     Channel locations are expanded to the full EEGLAB format.
     For more details see :func:`.utils.cart_to_eeglab_sph`.
+
+    Since 0.2.0, data is saved in matlabs v7.3 hdf5 format to support files large than 2GB
     """
 
     data = data * 1e6  # convert to microvolts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 scipy
+hdf5storage

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -5,3 +5,4 @@ sphinx_copybutton
 # readthedocs don't work without these
 numpy
 scipy
+hdf5storage


### PR DESCRIPTION
Hi!
this PR would fix #10 by defaulting to saving in matlabs  v7.3 format. That format is available since 2006 - maybe it is time to adopt it.

It is **breaking** (thus version to 0.2) in cases people rely on workflows that do not have `pymatreader` installed´

I have **not** run docs / tests, because i'm not super familiar with testing in python. I'm hoping there is a CI on github 🙈.

I didnt know where to put a changelog. Also I hope the PR is fine like this. Please feel free to change it if needed!
Cheers, Bene

PS: I havent checked if scipy is needed for something else than savemat, but you would probably know :)

