### PR TITLE
`numpy.records` deprecation work around (`eeglabio/epochs.py`)

### DIFF
--- a/eeglabio/epochs.py
+++ b/eeglabio/epochs.py
@@ -2,7 +2,7 @@ import numpy as np
 try:
     from numpy.rec import fromarrays  # NumPy 2.0+
 except ImportError:
-    from numpy.core.records import fromarrays # NumPy <2.0
+    from numpy.core.records import fromarrays  # NumPy <2.0
 
 from scipy.io import savemat
 


### PR DESCRIPTION
One other access of `numpy.records` was missed during the fix implemented by #15 .

MWE: 

```python 
import warnings
warnings.filterwarnings("error")

from eeglabio.utils import export_mne_epochs
```
