### PR TITLE
Handle special cases from MNE-Python

### DIFF
--- a/eeglabio/epochs.py
+++ b/eeglabio/epochs.py
@@ -61,6 +61,8 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
         this is necessary if epochs were dropped or reordered in MNE-Python,
         where events are no longer evenly aligned with epochs.
 
+        .. versionadded:: 0.1.2
+
     See Also
     --------
     .raw.export_set


### PR DESCRIPTION
This is a WIP. I am trying to get an MNE-Python test passing again:

https://github.com/mne-tools/mne-python/blob/936bfae75fc4604443e5dc3e16c095cd9bd612a2/mne/export/tests/test_export.py#L539

When using `export_set`, I think we hit two special cases with MNE-Python, one of which particularly comes from the  sample data `MNE.datasets.sample.data_path` 

1) When you load that dataset, `raw.first_samp` is something like 25,800. So all event latencies are offset from that number. 
2) If an MNE-Python user drops bad epochs before calling  ‘get_data’, then the epochs dimension of the array will not account for the true number of trials.

 AFAICT we need to account for these two occurences by allowing ther user to pass in a fist_samp and n_trials value to export_set