### PR TITLE
make some data copies optional

### DIFF
--- a/eeglabio/raw.py
+++ b/eeglabio/raw.py
@@ -10,7 +10,7 @@ from .utils import cart_to_eeglab, fname_to_setname
 
 
 def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
-               ref_channels="common", ch_types=None, precision="single"):
+               ref_channels="common", ch_types=None, precision="single", scale_data=True):
     """Export continuous raw data to EEGLAB's .set format.
 
     Parameters
@@ -43,7 +43,11 @@ def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
         ``"Events"``.
     precision : "single" or "double"
         Precision of the exported data (specifically EEG.data in EEGLAB)
-
+    scale_data : bool
+        by default assumes the data are in Volt, thus scales it with 1e6 to µV
+        for eeglab format export. Scaling requires a copy of the data, increasing
+        the memory-footprint.
+    
     See Also
     --------
     .epochs.export_set
@@ -52,17 +56,27 @@ def export_set(fname, data, sfreq, ch_names, ch_locs=None, annotations=None,
     -----
     Channel locations are expanded to the full EEGLAB format.
     For more details see :func:`.utils.cart_to_eeglab_sph`.
+    
+    In case memory is an issue, provide the data with the correct scaling, and
+    precision (e.g. in µV and data.astype("single",copy=False), and set `scale_data`
+    to `False`.
     """
 
     # Extact path stem for EEG.setname
     setname = fname_to_setname(fname)
-
-    data = data * 1e6  # convert to microvolts
+    if scale_data:
+        data = data * 1e6  # convert to microvolts
 
     if precision not in ("single", "double"):
         raise ValueError(f"Unsupported precision '{precision}', "
                          f"supported precisions are 'single' and 'double'.")
-    data = data.astype(precision)
+    if scale_data:
+        # we don't need another copy if we already scaled before
+        data = data.astype(precision, copy=False)
+    else:
+        # if one wants to save even this copy, one could convert already inplace
+        # prior to calling this function
+        data = data.astype(precision, copy=True) 
 
     # channel types
     ch_types = np.array(ch_types) if ch_types is not None \

--- a/eeglabio/utils.py
+++ b/eeglabio/utils.py
@@ -172,7 +172,7 @@ def export_mne_epochs(inst, fname, precision="single"):
                cart_coords, annot, precision=precision)
 
 
-def export_mne_raw(inst, fname, precision="single"):
+def export_mne_raw(inst, fname, precision="single", ):
     """Export MNE's Raw instance to EEGLAB's .set format using
     :func:`.raw.export_set`.
 
@@ -216,8 +216,8 @@ def export_mne_raw(inst, fname, precision="single"):
     ch_types = inst.get_channel_types()
     annotations = [inst.annotations.description, inst.annotations.onset,
                    inst.annotations.duration]
-    export_set(fname, inst.get_data(), inst.info['sfreq'], inst.ch_names,
-               cart_coords, annotations, ch_types=ch_types,
+    export_set(fname, inst.get_data(units="uV"), inst.info['sfreq'], inst.ch_names,
+               cart_coords, annotations, ch_types=ch_types,scale_data=False,
                precision=precision)
 
 

--- a/eeglabio/utils.py
+++ b/eeglabio/utils.py
@@ -172,7 +172,7 @@ def export_mne_epochs(inst, fname, precision="single"):
                cart_coords, annot, precision=precision)
 
 
-def export_mne_raw(inst, fname, precision="single", ):
+def export_mne_raw(inst, fname, precision="single"):
     """Export MNE's Raw instance to EEGLAB's .set format using
     :func:`.raw.export_set`.
 
@@ -216,8 +216,8 @@ def export_mne_raw(inst, fname, precision="single", ):
     ch_types = inst.get_channel_types()
     annotations = [inst.annotations.description, inst.annotations.onset,
                    inst.annotations.duration]
-    export_set(fname, inst.get_data(units="uV"), inst.info['sfreq'], inst.ch_names,
-               cart_coords, annotations, ch_types=ch_types,scale_data=False,
+    export_set(fname, inst.get_data(), inst.info['sfreq'], inst.ch_names,
+               cart_coords, annotations, ch_types=ch_types,
                precision=precision)
 
 


### PR DESCRIPTION
As discussed in #16, I introduce a new "scale_data=True" argument, which allows to provide data already scaled to uV. This saves one copy of the data in RAM without introducing side-effects.

Further, the precision conversion is done in-place in case scale_data=True already made a copy, but not if scale_data=False because we would potentially introduce  side-effects


