### PR TITLE
Fix epoch event mapping after dropped epochs

### DIFF
--- a/eeglabio/epochs.py
+++ b/eeglabio/epochs.py
@@ -54,9 +54,12 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
     precision : "single" or "double"
         Precision of the exported data (specifically EEG.data in EEGLAB)
     epoch_indices : numpy.ndarray or None
-        Original 0-based indices of the exported epochs. This parameter is
-        kept for compatibility; event positions are determined by the order
-        of ``data`` and ``events``.
+        1D integer array with one entry per event (same length as ``events``).
+        Each value gives the 0-based index of the exported epoch that the
+        corresponding event belongs to. This is needed when an epoch contains
+        more than one event. With one event per epoch, events are matched to
+        the data in order; non-consecutive MNE epoch selections are accepted
+        for compatibility.
 
         .. versionadded:: 0.1.2
 
@@ -83,8 +86,11 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
 
     ch_cnt, epoch_len, trials = data.shape
 
-    if len(events) != trials:
-        raise ValueError("events must contain one row per epoch")
+    if epoch_indices is None and len(events) != trials:
+        raise ValueError(
+            "The number of events must match the number of epochs in the "
+            "data when epoch_indices is not provided, but got "
+            f"{len(events)} events and {trials} epochs")
 
     if ch_locs is not None:
         # get full EEGLAB coordinates to export
@@ -108,29 +114,44 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
         ev_types = [str(ev[2]) for ev in events]
     ev_types = np.array(ev_types)
 
-    # MNE event samples refer to the original recording. EEGLAB stores event
-    # latency in the concatenated epoched data instead.
-    ev_epoch = np.arange(1, trials + 1, dtype=np.int64)
     zero_sample = int(round(-tmin * sfreq))
-    ev_lat = (ev_epoch - 1) * epoch_len + zero_sample + 1
+    if not 0 <= zero_sample < epoch_len:
+        logger.warning("The epoch window does not include time zero; events "
+                       "will be placed at the closest sample.")
+        zero_sample = min(max(zero_sample, 0), epoch_len - 1)
+    if epoch_indices is None:
+        ev_epoch = np.arange(1, trials + 1, dtype=np.int64)
+        ev_lat = (ev_epoch - 1) * epoch_len + zero_sample + 1
+    else:
+        epoch_indices = np.asarray(epoch_indices)
+        if epoch_indices.shape != (len(events),):
+            raise ValueError(
+                "epoch_indices must be a 1D array with one entry per event, "
+                f"but got shape {epoch_indices.shape} for {len(events)} "
+                "events")
+        if not np.issubdtype(epoch_indices.dtype, np.integer):
+            raise ValueError(
+                "epoch_indices must contain integers, but got dtype "
+                f"{epoch_indices.dtype}")
+        n_unique = len(np.unique(epoch_indices))
+        if len(events) == trials and n_unique == trials:
+            # MNE passes the original epoch selection here. These indices can
+            # be non-consecutive after epochs were dropped.
+            ev_epoch = np.arange(1, trials + 1, dtype=np.int64)
+            ev_lat = (ev_epoch - 1) * epoch_len + zero_sample + 1
+        else:
+            if (epoch_indices < 0).any() or (epoch_indices >= trials).any():
+                min_index = epoch_indices.min()
+                max_index = epoch_indices.max()
+                raise ValueError(
+                    "epoch_indices must be between 0 and "
+                    f"{trials - 1}, but got values from {min_index} to "
+                    f"{max_index}")
+            ev_epoch = epoch_indices.astype(np.int64) + 1
+            ev_lat = events[:, 0].astype(np.int64) + 1
 
     # event durations should all be 0 except boundaries which we don't have
     ev_dur = np.zeros_like(ev_lat, dtype=np.int64)
-
-    if epoch_indices is not None:
-        epoch_indices = np.asarray(epoch_indices)
-        if (
-            epoch_indices.shape != (trials,)
-            or len(np.unique(epoch_indices)) != trials
-        ):
-            raise ValueError(
-                "epoch_indices must contain one unique entry per epoch")
-    if len(ev_epoch) > 0 and max(ev_epoch) > trials:
-        # probably due to shifted/wrong events latency
-        # reset events to start at the beginning of each epoch
-        ev_epoch = np.arange(1, trials + 1, dtype=np.int64)
-        ev_lat = (ev_epoch - 1) * epoch_len
-        logger.warning("Invalid event latencies, ignored for export.")
 
     # merge annotations into events array
     if annotations is not None:
@@ -171,7 +192,7 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
         missing_epochs = required_epochs[missing_mask]
         all_types = np.append(all_types, np.full(len(missing_epochs), "dummy"))
         # set dummy events to start at the beginning of each epoch
-        all_lat = np.append(all_lat, (missing_epochs - 1) * epoch_len)
+        all_lat = np.append(all_lat, (missing_epochs - 1) * epoch_len + 1)
         all_dur = np.append(all_dur, np.zeros_like(missing_epochs))
         all_epoch = np.append(all_epoch, missing_epochs)
 

--- a/eeglabio/epochs.py
+++ b/eeglabio/epochs.py
@@ -54,12 +54,9 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
     precision : "single" or "double"
         Precision of the exported data (specifically EEG.data in EEGLAB)
     epoch_indices : numpy.ndarray or None
-        1D integer array with one entry per event (same length as ``events``).
-        Each value gives the 0-based epoch index that the corresponding event
-        belongs to. If None, events are assumed to map one-to-one with epochs
-        in order (first event → first epoch, second → second, etc.). Supplying
-        this is necessary if epochs were dropped or reordered in MNE-Python,
-        where events are no longer evenly aligned with epochs.
+        Original 0-based indices of the exported epochs. This parameter is
+        kept for compatibility; event positions are determined by the order
+        of ``data`` and ``events``.
 
         .. versionadded:: 0.1.2
 
@@ -86,6 +83,9 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
 
     ch_cnt, epoch_len, trials = data.shape
 
+    if len(events) != trials:
+        raise ValueError("events must contain one row per epoch")
+
     if ch_locs is not None:
         # get full EEGLAB coordinates to export
         full_coords = cart_to_eeglab(ch_locs)
@@ -108,18 +108,23 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
         ev_types = [str(ev[2]) for ev in events]
     ev_types = np.array(ev_types)
 
-    # EEGLAB latency, in units of data sample points
-    # ensure same int type (int64) as duration
-    ev_lat = events[:, 0].astype(np.int64) + 1  # +1 for eeglab indexing
+    # MNE event samples refer to the original recording. EEGLAB stores event
+    # latency in the concatenated epoched data instead.
+    ev_epoch = np.arange(1, trials + 1, dtype=np.int64)
+    zero_sample = int(round(-tmin * sfreq))
+    ev_lat = (ev_epoch - 1) * epoch_len + zero_sample + 1
 
     # event durations should all be 0 except boundaries which we don't have
     ev_dur = np.zeros_like(ev_lat, dtype=np.int64)
 
-    # indices of epochs each event belongs to
-    ev_epoch = ev_lat // epoch_len + 1
     if epoch_indices is not None:
-        # full-slice assigment to ensure epoch_indices.shape == ev_lat.shape
-        ev_epoch[:] = epoch_indices
+        epoch_indices = np.asarray(epoch_indices)
+        if (
+            epoch_indices.shape != (trials,)
+            or len(np.unique(epoch_indices)) != trials
+        ):
+            raise ValueError(
+                "epoch_indices must contain one unique entry per epoch")
     if len(ev_epoch) > 0 and max(ev_epoch) > trials:
         # probably due to shifted/wrong events latency
         # reset events to start at the beginning of each epoch
@@ -155,10 +160,7 @@ def export_set(fname, data, sfreq, events, tmin, tmax, ch_names, event_id=None,
 
     # check there's at least one event per epoch
     uniq_epochs = np.unique(all_epoch)
-    if epoch_indices is None:
-        required_epochs = np.arange(1, trials + 1)
-    else:
-        required_epochs = epoch_indices
+    required_epochs = np.arange(1, trials + 1)
     if not np.array_equal(uniq_epochs, required_epochs):
         # doesn't meet the requirement of at least one event per epoch
         # add dummy events to satisfy this

--- a/eeglabio/tests/test_epochs.py
+++ b/eeglabio/tests/test_epochs.py
@@ -5,8 +5,10 @@ import numpy as np
 import pytest
 from mne import read_events, pick_types, Epochs, read_epochs_eeglab
 from mne.io import read_raw_fif
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
+from scipy.io import loadmat
 
+from eeglabio.epochs import export_set
 from eeglabio.utils import export_mne_epochs
 
 raw_fname = Path(__file__).parent / "data" / "test_raw.fif"
@@ -53,3 +55,41 @@ def test_export_set(tmpdir, preload):
     assert epochs.event_id.keys() == epochs_read.event_id.keys()  # just keys
     assert_allclose(epochs.times, epochs_read.times)
     assert_allclose(epochs.get_data(), epochs_read.get_data())
+
+
+@pytest.mark.parametrize(('tmax', 'n_times'), ((0.2, 31), (0.0, 11)))
+def test_export_set_dropped_epochs(tmp_path, tmax, n_times):
+    """Map retained MNE events to consecutive EEGLAB epochs."""
+    sfreq = 100.0
+    n_epochs = 3
+    data = np.zeros((n_epochs, 1, n_times))
+    events = np.column_stack((
+        [100, 300, 500],
+        np.zeros(n_epochs, dtype=int),
+        [1, 2, 3],
+    ))
+    event_id = {f'event-{code}': code for code in events[:, 2]}
+    fname = tmp_path / 'dropped.set'
+
+    export_set(
+        fname=fname,
+        data=data,
+        sfreq=sfreq,
+        events=events,
+        tmin=-0.1,
+        tmax=tmax,
+        ch_names=['Cz'],
+        event_id=event_id,
+    )
+    epochs_read = read_epochs_eeglab(fname, verbose='error')
+
+    zero_sample = int(round(0.1 * sfreq))
+    expected = np.arange(n_epochs) * n_times + zero_sample
+
+    eeglab = loadmat(fname, squeeze_me=True, struct_as_record=False)
+    mat_events = np.atleast_1d(eeglab['event'])
+    assert_array_equal([event.latency for event in mat_events], expected + 1)
+    assert_array_equal([event.epoch for event in mat_events], [1, 2, 3])
+
+    assert_array_equal(epochs_read.events[:, 0], expected)
+    assert set(epochs_read.event_id) == set(event_id)

--- a/eeglabio/tests/test_epochs.py
+++ b/eeglabio/tests/test_epochs.py
@@ -50,15 +50,20 @@ def test_export_set(tmpdir, preload):
     assert_allclose(cart_coords, cart_coords_read)
     assert len(epochs) == len(epochs_read)
     assert len(epochs_read.events) == len(epochs)
-    # assert_array_equal(epochs.events[:, 0],
-    #                    epochs_read.events[:, 0])  # latency
+    event_samples = (
+        np.arange(len(epochs)) * len(epochs.times)
+        + epochs.time_as_index(0)[0]
+    )
+    assert_array_equal(event_samples, epochs_read.events[:, 0])
     assert epochs.event_id.keys() == epochs_read.event_id.keys()  # just keys
     assert_allclose(epochs.times, epochs_read.times)
     assert_allclose(epochs.get_data(), epochs_read.get_data())
 
 
 @pytest.mark.parametrize(('tmax', 'n_times'), ((0.2, 31), (0.0, 11)))
-def test_export_set_dropped_epochs(tmp_path, tmax, n_times):
+@pytest.mark.parametrize('pass_epoch_indices', (False, True))
+def test_export_set_dropped_epochs(
+        tmp_path, tmax, n_times, pass_epoch_indices):
     """Map retained MNE events to consecutive EEGLAB epochs."""
     sfreq = 100.0
     n_epochs = 3
@@ -71,7 +76,7 @@ def test_export_set_dropped_epochs(tmp_path, tmax, n_times):
     event_id = {f'event-{code}': code for code in events[:, 2]}
     fname = tmp_path / 'dropped.set'
 
-    export_set(
+    kwargs = dict(
         fname=fname,
         data=data,
         sfreq=sfreq,
@@ -81,6 +86,9 @@ def test_export_set_dropped_epochs(tmp_path, tmax, n_times):
         ch_names=['Cz'],
         event_id=event_id,
     )
+    if pass_epoch_indices:
+        kwargs['epoch_indices'] = np.array([0, 2, 4])
+    export_set(**kwargs)
     epochs_read = read_epochs_eeglab(fname, verbose='error')
 
     zero_sample = int(round(0.1 * sfreq))
@@ -93,3 +101,81 @@ def test_export_set_dropped_epochs(tmp_path, tmax, n_times):
 
     assert_array_equal(epochs_read.events[:, 0], expected)
     assert set(epochs_read.event_id) == set(event_id)
+
+
+def test_export_set_multiple_events(tmp_path):
+    """Preserve multiple events within an epoch."""
+    data = np.zeros((3, 1, 11))
+    events = np.column_stack((
+        [2, 8, 15, 29],
+        np.zeros(4, dtype=int),
+        [1, 2, 3, 4],
+    ))
+    fname = tmp_path / 'multiple.set'
+    export_set(
+        fname=fname,
+        data=data,
+        sfreq=100.0,
+        events=events,
+        tmin=-0.1,
+        tmax=0.0,
+        ch_names=['Cz'],
+        epoch_indices=np.array([0, 0, 1, 2]),
+    )
+
+    eeglab = loadmat(fname, squeeze_me=True, struct_as_record=False)
+    mat_events = np.atleast_1d(eeglab['event'])
+    latencies = [event.latency for event in mat_events]
+    assert_array_equal(latencies, events[:, 0] + 1)
+    assert_array_equal([event.epoch for event in mat_events], [1, 1, 2, 3])
+
+
+@pytest.mark.parametrize(('tmin', 'tmax', 'expected'), (
+    (0.1, 0.2, [1, 12]),
+    (-0.2, -0.1, [11, 22]),
+))
+def test_export_set_without_time_zero(tmp_path, tmin, tmax, expected):
+    """Keep event latencies valid when the epoch excludes time zero."""
+    fname = tmp_path / 'no-zero.set'
+    export_set(
+        fname=fname,
+        data=np.zeros((2, 1, 11)),
+        sfreq=100.0,
+        events=np.array([[100, 0, 1], [300, 0, 2]]),
+        tmin=tmin,
+        tmax=tmax,
+        ch_names=['Cz'],
+    )
+
+    eeglab = loadmat(fname, squeeze_me=True, struct_as_record=False)
+    mat_events = np.atleast_1d(eeglab['event'])
+    assert_array_equal([event.latency for event in mat_events], expected)
+    assert_array_equal([event.epoch for event in mat_events], [1, 2])
+
+
+def test_export_set_epoch_index_validation(tmp_path):
+    """Report mismatched event and epoch index counts."""
+    data = np.zeros((3, 1, 11))
+    events = np.column_stack((
+        [100, 300, 500],
+        np.zeros(3, dtype=int),
+        [1, 2, 3],
+    ))
+    kwargs = dict(
+        fname=tmp_path / 'invalid.set',
+        data=data,
+        sfreq=100.0,
+        events=events,
+        tmin=-0.1,
+        tmax=0.0,
+        ch_names=['Cz'],
+    )
+
+    with pytest.raises(ValueError, match='2 events and 3 epochs'):
+        export_set(**{**kwargs, 'events': events[:2]})
+    with pytest.raises(ValueError, match=r'got shape \(3, 1\)'):
+        export_set(**kwargs, epoch_indices=np.array([[0], [2], [4]]))
+    with pytest.raises(ValueError, match='got dtype float64'):
+        export_set(**kwargs, epoch_indices=np.array([0.0, 2.0, 4.0]))
+    with pytest.raises(ValueError, match='values from 0 to 3'):
+        export_set(**kwargs, epoch_indices=np.array([0, 0, 3]))


### PR DESCRIPTION
When MNE epochs have been dropped, their event samples still refer to the original continuous recording. eeglabio treated those samples as positions in the concatenated epoched data, which could produce out-of-range epoch numbers, reset latencies, and dummy events.

This maps one time-locking event per exported trial to its position in the concatenated EEGLAB dataset. Non-consecutive MNE selections are accepted, but the exported EEGLAB trial numbers follow the actual data order. When `epoch_indices` maps multiple events to each exported epoch, their existing positions within the concatenated data are preserved.

The tests cover standard MNE export, dropped middle epochs, the `tmax=0` boundary, windows that exclude time zero, multiple events per epoch, and invalid index mappings.

Related to mne-tools/mne-python#13535 and mne-tools/mne-python#14067.
